### PR TITLE
made weekplan skeleton, and card, made cool toggle button between the two on saved page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { HomePage } from './pages/home-page';
 import ProfilePage from './pages/profile-page';
 import { SavedPage } from './pages/saved-page';
 import RecipeDetail from './pages/recipe-detail';
+import { WeekplanPage } from './pages/weekplan-page';
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
           <Route path="/saved" element={<SavedPage />} />
           <Route path="/recipe/:id" element={<RecipeDetail />} />
           <Route path="/profile" element={<ProfilePage />} />
+          <Route path="/weekplans" element={<WeekplanPage />} />
         </Routes>
       </BrowserRouter>
     </SavedRecipesProvider>

--- a/src/components/saved-page-header.tsx
+++ b/src/components/saved-page-header.tsx
@@ -1,8 +1,8 @@
-import { Plus } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { Calendar, ChefHat } from 'lucide-react';
 import type { FilterState } from './filter-panel';
 import { FilterPanel } from './filter-panel';
 import type { Recipe } from '../types/recipe';
+import type { ViewMode } from '../pages/saved-page';
 
 interface SavedPageHeaderProps {
   filteredCount: number;
@@ -11,6 +11,8 @@ interface SavedPageHeaderProps {
   recipes: Recipe[];
   desktopFiltersExpanded: boolean;
   onDesktopFiltersToggle: (expanded: boolean) => void;
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
 }
 
 export function SavedPageHeader({
@@ -20,40 +22,67 @@ export function SavedPageHeader({
   recipes,
   desktopFiltersExpanded,
   onDesktopFiltersToggle,
+  viewMode,
+  onViewModeChange,
 }: SavedPageHeaderProps) {
   return (
     <header className="hidden md:block bg-white border-b border-gray-200 px-6 py-6 sticky top-0 z-30">
       {/* Title row */}
       <div className="flex items-center justify-between gap-4 mb-4 min-w-0">
         <div className="min-w-0">
-          <h1 className="text-2xl font-bold text-gray-900 truncate">Saved Recipes</h1>
+          <h1 className="text-2xl font-bold text-gray-900 truncate">
+            {viewMode === 'recipes' ? 'Saved Recipes' : 'Week Plans'}
+          </h1>
           <p className="text-sm text-gray-600 mt-1">
-            {filteredCount} recipe{filteredCount !== 1 ? 's' : ''} found
+            {viewMode === 'recipes'
+              ? `${filteredCount} recipe${filteredCount !== 1 ? 's' : ''} found`
+              : 'Dine lagrede ukeplaner – legg til, rediger eller bestill når du vil.'}
           </p>
         </div>
-        <Link
-          to="/weekplans/new"
-          className="flex items-center gap-2 px-4 py-2.5 bg-orange-500 hover:bg-orange-600 text-white rounded-xl transition-colors font-medium shadow-sm shrink-0"
-        >
-          <Plus size={18} />
-          <span>Create Weekplan</span>
-        </Link>
+
+        {/* Toggle Button */}
+        <div className="flex items-center gap-2 bg-gray-100 rounded-xl p-1 shrink-0">
+          <button
+            onClick={() => onViewModeChange('recipes')}
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-all font-medium ${
+              viewMode === 'recipes'
+                ? 'bg-white text-gray-900 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            <ChefHat size={18} />
+            <span>Recipes</span>
+          </button>
+          <button
+            onClick={() => onViewModeChange('weekplans')}
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-all font-medium ${
+              viewMode === 'weekplans'
+                ? 'bg-white text-gray-900 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            <Calendar size={18} />
+            <span>Weekplans</span>
+          </button>
+        </div>
       </div>
 
       {/* --- visual separation line --- */}
       <hr className="border-gray-200 mb-4" />
 
-      {/* Filter panel (contains search + dropdowns) */}
-      <div className="space-y-4">
-        {/* First, the FilterPanel search bar */}
-        <FilterPanel
-          filters={filters}
-          onChange={onFiltersChange}
-          recipes={recipes}
-          showFilters={desktopFiltersExpanded}
-          onToggleFilters={onDesktopFiltersToggle}
-        />
-      </div>
+      {/* Filter panel (contains search + dropdowns) - Only show for recipes view */}
+      {viewMode === 'recipes' && (
+        <div className="space-y-4">
+          {/* First, the FilterPanel search bar */}
+          <FilterPanel
+            filters={filters}
+            onChange={onFiltersChange}
+            recipes={recipes}
+            showFilters={desktopFiltersExpanded}
+            onToggleFilters={onDesktopFiltersToggle}
+          />
+        </div>
+      )}
     </header>
   );
 }

--- a/src/components/weekplan-card.tsx
+++ b/src/components/weekplan-card.tsx
@@ -1,0 +1,19 @@
+export function WeekplanCard({
+  title,
+  author,
+  onClick,
+}: {
+  title: string;
+  author: string;
+  onClick?: () => void;
+}) {
+  return (
+    <div
+      onClick={onClick}
+      className="cursor-pointer bg-white rounded-2xl shadow-sm border border-gray-200 p-5 hover:shadow-md transition"
+    >
+      <h2 className="text-xl font-semibold text-gray-900 mb-1">{title}</h2>
+      <p className="text-gray-500 text-sm">av {author}</p>
+    </div>
+  );
+}

--- a/src/pages/saved-page.tsx
+++ b/src/pages/saved-page.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Menu } from 'lucide-react';
+import { Menu, ChefHat, Calendar } from 'lucide-react';
 import { RecipeCard } from '../components/recipe-card';
 import { FilterPanel, type FilterState } from '../components/filter-panel';
 import { SavedPageNavbar } from '../components/navbar';
@@ -100,14 +100,38 @@ export function SavedPage() {
 
       {/* Main Content */}
       <div className="flex-1 flex flex-col min-w-0">
-        {/* Mobile Header */}
-        <header className="bg-white border-b border-gray-200 px-4 py-4 flex items-center gap-4 sticky top-0 z-30 md:hidden">
-          <button onClick={() => setNavOpen(true)} className="p-2 hover:bg-gray-100 rounded-lg">
-            <Menu size={24} className="text-gray-700" />
-          </button>
-          <h1 className="text-xl font-bold text-gray-900">
-            {viewMode === 'recipes' ? 'Saved Recipes' : 'Week Plans'}
-          </h1>
+        {/* Mobile Saved Page Header */}
+        <header className="bg-white border-b border-gray-200 px-4 py-4 flex items-center justify-between gap-4 sticky top-0 z-30 md:hidden">
+          <div className="flex items-center gap-4">
+            <button onClick={() => setNavOpen(true)} className="p-2 hover:bg-gray-100 rounded-lg">
+              <Menu size={24} className="text-gray-700" />
+            </button>
+            <h1 className="text-xl font-bold text-gray-900">
+              {viewMode === 'recipes' ? 'Saved Recipes' : 'Week Plans'}
+            </h1>
+          </div>
+
+          {/* Mobile view toggle - compact icon buttons */}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setViewMode('recipes')}
+              aria-label="Show recipes"
+              className={`p-2 rounded-md transition ${
+                viewMode === 'recipes' ? 'bg-gray-100 text-gray-900' : 'text-gray-500'
+              }`}
+            >
+              <ChefHat size={18} />
+            </button>
+            <button
+              onClick={() => setViewMode('weekplans')}
+              aria-label="Show weekplans"
+              className={`p-2 rounded-md transition ${
+                viewMode === 'weekplans' ? 'bg-gray-100 text-gray-900' : 'text-gray-500'
+              }`}
+            >
+              <Calendar size={18} />
+            </button>
+          </div>
         </header>
 
         {/* Desktop Dashboard Header */}

--- a/src/pages/saved-page.tsx
+++ b/src/pages/saved-page.tsx
@@ -4,12 +4,16 @@ import { RecipeCard } from '../components/recipe-card';
 import { FilterPanel, type FilterState } from '../components/filter-panel';
 import { SavedPageNavbar } from '../components/navbar';
 import { SavedPageHeader } from '../components/saved-page-header';
+import { WeekplanCard } from '../components/weekplan-card';
 import { useSavedRecipesContext } from '../context/SavedRecipesContext';
 import { ALL_RECIPES } from '../utils/recipe-loader';
+
+export type ViewMode = 'recipes' | 'weekplans';
 
 export function SavedPage() {
   const { isSaved } = useSavedRecipesContext();
   const [navOpen, setNavOpen] = useState(false);
+  const [viewMode, setViewMode] = useState<ViewMode>('recipes');
   const [filters, setFilters] = useState<FilterState>({
     kitchen: 'all',
     difficulty: 'all',
@@ -22,6 +26,13 @@ export function SavedPage() {
   const [mobileFiltersExpanded, setMobileFiltersExpanded] = useState(false);
   const [desktopFiltersExpanded, setDesktopFiltersExpanded] = useState(false);
   const lastScrollY = useRef(0);
+
+  // Mock weekplans data - replace with actual data source later
+  const weekplans = [
+    { title: 'Uke 42 – Middager', author: 'Lina' },
+    { title: 'Uke 43 – Kjappe retter', author: 'Lina' },
+    { title: 'Uke 44 – Vegetar', author: 'Lina' },
+  ];
 
   // Auto-hide mobile filter bar on scroll down, show on scroll up
   useEffect(() => {
@@ -94,7 +105,9 @@ export function SavedPage() {
           <button onClick={() => setNavOpen(true)} className="p-2 hover:bg-gray-100 rounded-lg">
             <Menu size={24} className="text-gray-700" />
           </button>
-          <h1 className="text-xl font-bold text-gray-900">Saved Recipes</h1>
+          <h1 className="text-xl font-bold text-gray-900">
+            {viewMode === 'recipes' ? 'Saved Recipes' : 'Week Plans'}
+          </h1>
         </header>
 
         {/* Desktop Dashboard Header */}
@@ -105,71 +118,100 @@ export function SavedPage() {
           recipes={recipesToShow}
           desktopFiltersExpanded={desktopFiltersExpanded}
           onDesktopFiltersToggle={setDesktopFiltersExpanded}
+          viewMode={viewMode}
+          onViewModeChange={setViewMode}
         />
 
         {/* Main Content Area */}
         <main className="flex-1 p-4 pb-32 md:p-6 md:pb-6">
-          {/* Recipe Grid or Empty State */}
-          {savedRecipes.length === 0 ? (
-            <div className="text-center py-12">
-              <p className="text-gray-500 text-lg mb-2">No saved recipes yet</p>
-              <p className="text-sm text-gray-400">
-                Start adding recipes by clicking the heart icon on any recipe from the home page
-              </p>
-            </div>
-          ) : filteredRecipes.length === 0 ? (
-            <div className="text-center py-12">
-              <p className="text-gray-500">No recipes match your filters</p>
-              <p className="text-sm text-gray-400 mt-2">
-                Try adjusting your filters or clearing them
-              </p>
-            </div>
-          ) : (
-            <div className="relative">
-              {/* Overlay to intercept clicks when desktop filters are expanded */}
-              {desktopFiltersExpanded && (
-                <div
-                  className="hidden md:block absolute inset-0 z-10 cursor-pointer"
-                  onClick={() => setDesktopFiltersExpanded(false)}
-                />
+          {viewMode === 'recipes' ? (
+            /* Recipe Grid or Empty State */
+            <>
+              {savedRecipes.length === 0 ? (
+                <div className="text-center py-12">
+                  <p className="text-gray-500 text-lg mb-2">No saved recipes yet</p>
+                  <p className="text-sm text-gray-400">
+                    Start adding recipes by clicking the heart icon on any recipe from the home page
+                  </p>
+                </div>
+              ) : filteredRecipes.length === 0 ? (
+                <div className="text-center py-12">
+                  <p className="text-gray-500">No recipes match your filters</p>
+                  <p className="text-sm text-gray-400 mt-2">
+                    Try adjusting your filters or clearing them
+                  </p>
+                </div>
+              ) : (
+                <div className="relative">
+                  {/* Overlay to intercept clicks when desktop filters are expanded */}
+                  {desktopFiltersExpanded && (
+                    <div
+                      className="hidden md:block absolute inset-0 z-10 cursor-pointer"
+                      onClick={() => setDesktopFiltersExpanded(false)}
+                    />
+                  )}
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                    {filteredRecipes.map((recipe) => (
+                      <RecipeCard key={recipe.id} recipe={recipe} />
+                    ))}
+                  </div>
+                </div>
               )}
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                {filteredRecipes.map((recipe) => (
-                  <RecipeCard key={recipe.id} recipe={recipe} />
-                ))}
-              </div>
-            </div>
+            </>
+          ) : (
+            /* Weekplans Grid or Empty State */
+            <>
+              {weekplans.length === 0 ? (
+                <div className="text-center py-12">
+                  <p className="text-gray-500 text-lg mb-2">Du har ingen ukeplaner ennå</p>
+                  <p className="text-sm text-gray-400">Opprett din første ukeplan nå!</p>
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+                  {weekplans.map((plan, i) => (
+                    <WeekplanCard
+                      key={i}
+                      title={plan.title}
+                      author={plan.author}
+                      onClick={() => console.log('Åpne', plan.title)}
+                    />
+                  ))}
+                </div>
+              )}
+            </>
           )}
         </main>
 
         {/* Mobile Filter Overlay */}
-        {mobileFiltersExpanded && (
+        {mobileFiltersExpanded && viewMode === 'recipes' && (
           <div
             className="md:hidden fixed inset-0 bg-black/20 z-10"
             onClick={() => setMobileFiltersExpanded(false)}
           />
         )}
 
-        {/* Mobile Floating Filter Bar */}
-        <div
-          className={`
-            md:hidden fixed bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-gray-50 via-gray-50 to-transparent
-            transition-transform duration-300 ease-in-out z-20
-            ${showMobileFilter && !navOpen ? 'translate-y-0' : 'translate-y-full'}
-          `}
-        >
-          <div className="flex items-end gap-3">
-            <div className="flex-1">
-              <FilterPanel
-                filters={filters}
-                onChange={setFilters}
-                recipes={recipesToShow}
-                showFilters={mobileFiltersExpanded}
-                onToggleFilters={setMobileFiltersExpanded}
-              />
+        {/* Mobile Floating Filter Bar - Only show for recipes view */}
+        {viewMode === 'recipes' && (
+          <div
+            className={`
+              md:hidden fixed bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-gray-50 via-gray-50 to-transparent
+              transition-transform duration-300 ease-in-out z-20
+              ${showMobileFilter && !navOpen ? 'translate-y-0' : 'translate-y-full'}
+            `}
+          >
+            <div className="flex items-end gap-3">
+              <div className="flex-1">
+                <FilterPanel
+                  filters={filters}
+                  onChange={setFilters}
+                  recipes={recipesToShow}
+                  showFilters={mobileFiltersExpanded}
+                  onToggleFilters={setMobileFiltersExpanded}
+                />
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/weekplan-page.tsx
+++ b/src/pages/weekplan-page.tsx
@@ -41,7 +41,7 @@ export function WeekplanPage() {
         {/* Tom tilstand */}
         {weekplans.length === 0 && (
           <div className="text-center text-gray-500 py-20">
-            Du har ingen ukeplaner ennå. Opprett din første nå!
+            You don't have any saved week plans yet.
           </div>
         )}
       </main>

--- a/src/pages/weekplan-page.tsx
+++ b/src/pages/weekplan-page.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { SavedPageNavbar } from '../components/navbar';
+import { WeekplanCard } from '../components/weekplan-card';
+
+export function WeekplanPage() {
+  const [navOpen, setNavOpen] = useState(false);
+
+  const weekplans = [
+    { title: 'Uke 42 – Middager', author: 'Lina' },
+    { title: 'Uke 43 – Kjappe retter', author: 'Lina' },
+    { title: 'Uke 44 – Vegetar', author: 'Lina' },
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex overflow-x-clip">
+      {/* Left Navbar */}
+      <SavedPageNavbar isOpen={navOpen} onClose={() => setNavOpen(false)} />
+
+      {/* Main Content */}
+      <main className="flex-1 p-6 space-y-6">
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Saved Week Plans</h1>
+            <p className="text-gray-600 mt-1"></p>
+          </div>
+        </div>
+
+        {/* Weekplan grid */}
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+          {weekplans.map((plan, i) => (
+            <WeekplanCard
+              key={i}
+              title={plan.title}
+              author={plan.author}
+              onClick={() => console.log('Åpne', plan.title)}
+            />
+          ))}
+        </div>
+
+        {/* Tom tilstand */}
+        {weekplans.length === 0 && (
+          <div className="text-center text-gray-500 py-20">
+            Du har ingen ukeplaner ennå. Opprett din første nå!
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
- Refactor: Create a single, prop-driven header component that supports both Recipes and Weekplans views
- Feature: Implement a FilterPanel variant for Weekplans (simplified filters – e.g. by author, tags, or date range)
- Database: Create weekplans and weekplan_entries tables in Supabase